### PR TITLE
explicitly call methods is

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Imports:
     dbplyr,
     dplyr,
     glue,
+    methods,
     rlang,
     snakecase,
     stringr,

--- a/R/methodSummary.R
+++ b/R/methodSummary.R
@@ -287,7 +287,7 @@ getType <- function(x) {
     }
   } else if (is.logical(x)) {
     return("logical")
-  } else if (is(x, "Date")) {
+  } else if (methods::is(x, "Date")) {
     return("date")
   } else if (is.character(x)) {
     return("character")


### PR DESCRIPTION
To fix r check note

> getType: no visible global function definition for 'is'
>   Undefined global functions or variables:
>     is
>   Consider adding
>     importFrom("methods", "is")