### PR TITLE
include sys time in temp table name

### DIFF
--- a/R/compute.R
+++ b/R/compute.R
@@ -68,7 +68,7 @@ uniqueTableName <- function(prefix = "") {
   assertCharacter(x = prefix, length = 1)
   i <- getOption("dbplyr_table_name", 0) + 1
   options(dbplyr_table_name = i)
-  value <- paste0(sprintf("dbplyr_%03i", i), "_", round(as.numeric(Sys.time())))
+  value <- paste0(sprintf("og_%03i", i), "_", round(as.numeric(Sys.time())))
   paste0(prefix, value)
 }
 

--- a/R/compute.R
+++ b/R/compute.R
@@ -68,7 +68,8 @@ uniqueTableName <- function(prefix = "") {
   assertCharacter(x = prefix, length = 1)
   i <- getOption("dbplyr_table_name", 0) + 1
   options(dbplyr_table_name = i)
-  paste0(prefix, sprintf("dbplyr_%03i", i))
+  value <- paste0(sprintf("dbplyr_%03i", i), "_", round(as.numeric(Sys.time())))
+  paste0(prefix, value)
 }
 
 #' Create a temporary prefix for tables, that contains a unique prefix that

--- a/tests/testthat/test-prefix.R
+++ b/tests/testthat/test-prefix.R
@@ -1,10 +1,10 @@
 test_that("prefix", {
   # unique table name
   options(dbplyr_table_name = 0)
-  expect_true(stringr::str_starts(uniqueTableName(), "dbplyr_001"))
-  expect_true(stringr::str_starts(uniqueTableName(),"dbplyr_002"))
+  expect_true(stringr::str_starts(uniqueTableName(), "og_001"))
+  expect_true(stringr::str_starts(uniqueTableName(),"og_002"))
   options(dbplyr_table_name = 100)
-  expect_true(stringr::str_starts(uniqueTableName(), "dbplyr_101"))
+  expect_true(stringr::str_starts(uniqueTableName(), "og_101"))
 
   # temporary prefix
   options(tmp_prefix_number = 0)
@@ -18,11 +18,11 @@ test_that("prefix", {
   # table with prefix
   options(tmp_prefix_number = 111)
   expect_no_error(x <- uniqueTableName(tmpPrefix()))
-  expect_true(nchar(x) == 29)
+  expect_true(nchar(x) == 25)
   x <- x |> strsplit(split = "_") |> unlist()
   expect_true(length(x) == 5)
   expect_true(x[1] == "tmp")
   expect_true(x[2] == "112")
-  expect_true(x[3] == "dbplyr")
+  expect_true(x[3] == "og")
   expect_true(x[4] == "102")
 })

--- a/tests/testthat/test-prefix.R
+++ b/tests/testthat/test-prefix.R
@@ -1,10 +1,10 @@
 test_that("prefix", {
   # unique table name
   options(dbplyr_table_name = 0)
-  expect_true(uniqueTableName() == "dbplyr_001")
-  expect_true(uniqueTableName() == "dbplyr_002")
+  expect_true(stringr::str_starts(uniqueTableName(), "dbplyr_001"))
+  expect_true(stringr::str_starts(uniqueTableName(),"dbplyr_002"))
   options(dbplyr_table_name = 100)
-  expect_true(uniqueTableName() == "dbplyr_101")
+  expect_true(stringr::str_starts(uniqueTableName(), "dbplyr_101"))
 
   # temporary prefix
   options(tmp_prefix_number = 0)
@@ -16,12 +16,13 @@ test_that("prefix", {
   expect_true(getOption("tmp_prefix_number") == 124)
 
   # table with prefix
+  options(tmp_prefix_number = 111)
   expect_no_error(x <- uniqueTableName(tmpPrefix()))
-  expect_true(nchar(x) == 18)
+  expect_true(nchar(x) == 29)
   x <- x |> strsplit(split = "_") |> unlist()
-  expect_true(length(x) == 4)
+  expect_true(length(x) == 5)
   expect_true(x[1] == "tmp")
-  expect_true(x[2] == "125")
+  expect_true(x[2] == "112")
   expect_true(x[3] == "dbplyr")
   expect_true(x[4] == "102")
 })


### PR DESCRIPTION
For discussion - one possible approach to avoid conflicting temp tables between sessions