### PR TITLE
cohort error if not permanent tbl

### DIFF
--- a/R/classCohortTable.R
+++ b/R/classCohortTable.R
@@ -578,9 +578,15 @@ populateCohortSet <- function(table, cohortSetRef) {
   }
   cohortName <- tableName(table)
   if(is.na(cohortName)){
-    cli::cli_abort(c("x" = "Table name for cohort could not be inferred.",
-                     "i" = "The cohort table must be a permanent table when working with databases.",
-                     "i" = "Use dplyr::compute(temporary = FALSE, ...) to create a permanent table from a temporary table."))
+   if(cdmSourceType(cdm) == "local"){
+     cli::cli_abort(c("x" = "Table name for cohort could not be inferred.",
+                      "i" = "Did you use insertTable() when adding the table to the cdm reference?"))
+
+   } else {
+     cli::cli_abort(c("x" = "Table name for cohort could not be inferred.",
+                      "i" = "The cohort table must be a permanent table when working with databases.",
+                      "i" = "Use dplyr::compute(temporary = FALSE, ...) to create a permanent table from a temporary table."))
+   }
   }
   assertClass(cohortSetRef, "data.frame", null = TRUE)
   cohortSetRef <- dplyr::as_tibble(cohortSetRef)

--- a/R/classCohortTable.R
+++ b/R/classCohortTable.R
@@ -577,6 +577,11 @@ populateCohortSet <- function(table, cohortSetRef) {
     cohortSetRef <- cohortSetRef |> dplyr::collect()
   }
   cohortName <- tableName(table)
+  if(is.na(cohortName)){
+    cli::cli_abort(c("x" = "Table name for cohort could not be inferred.",
+                     "i" = "The cohort table must be a permanent table when working with databases.",
+                     "i" = "Use dplyr::compute(temporary = FALSE, ...) to create a permanent table from a temporary table."))
+  }
   assertClass(cohortSetRef, "data.frame", null = TRUE)
   cohortSetRef <- dplyr::as_tibble(cohortSetRef)
   name <- ifelse(is.na(cohortName), cohortName, paste0(cohortName, "_set"))

--- a/R/classCohortTable.R
+++ b/R/classCohortTable.R
@@ -578,15 +578,7 @@ populateCohortSet <- function(table, cohortSetRef) {
   }
   cohortName <- tableName(table)
   if(is.na(cohortName)){
-   if(cdmSourceType(cdm) == "local"){
-     cli::cli_abort(c("x" = "Table name for cohort could not be inferred.",
-                      "i" = "Did you use insertTable() when adding the table to the cdm reference?"))
-
-   } else {
-     cli::cli_abort(c("x" = "Table name for cohort could not be inferred.",
-                      "i" = "The cohort table must be a permanent table when working with databases.",
-                      "i" = "Use dplyr::compute(temporary = FALSE, ...) to create a permanent table from a temporary table."))
-   }
+    missingCohortTableNameError(cdm, validation = "error")
   }
   assertClass(cohortSetRef, "data.frame", null = TRUE)
   cohortSetRef <- dplyr::as_tibble(cohortSetRef)
@@ -699,4 +691,34 @@ getEmptyField <- function(datatype) {
     "logical" = logical()
   )
   return(empty)
+}
+
+missingCohortTableNameError <- function(cdm, validation = "error"){
+
+if(validation == "error"){
+  if(cdmSourceType(cdm) == "local"){
+    cli::cli_abort(c("x" = "Table name for cohort could not be inferred.",
+                     "i" = "Did you use insertTable() when adding the table to the cdm reference?"))
+
+  } else {
+    cli::cli_abort(c("x" = "Table name for cohort could not be inferred.",
+                     "i" = "The cohort table must be a permanent table when working with databases.",
+                     "i" = "Use dplyr::compute(temporary = FALSE, ...) to create a permanent table from a temporary table."))
+  }
+} else if (validation == "warning"){
+  if(cdmSourceType(cdm) == "local"){
+    cli::cli_warn(c("Table name for cohort could not be inferred.",
+                     "i" = "Did you use insertTable() when adding the table to the cdm reference?"))
+
+  } else {
+    cli::cli_warn(c("Table name for cohort could not be inferred.",
+                     "i" = "The cohort table must be a permanent table when working with databases.",
+                     "i" = "Use dplyr::compute(temporary = FALSE, ...) to create a permanent table from a temporary table."))
+  }
+} else {
+
+  return(invisible())
+}
+
+
 }

--- a/R/validate.R
+++ b/R/validate.R
@@ -83,10 +83,16 @@ validateCohortArgument <- function(cohort,
   assertClass(cohort, class = c("cohort_table", "cdm_table"), all = TRUE, call = call)
 
   if(is.na(tableName(cohort))){
-    cli::cli_abort(c("x" = "Table name for cohort could not be inferred.",
-                     "i" = "The cohort table must be a permanent table when working with databases.",
-                     "i" = "Use dplyr::compute(temporary = FALSE, ...) to create a permanent table from a temporary table."))
-  }
+    if(cdmSourceType(cdm) == "local"){
+      cli::cli_abort(c("x" = "Table name for cohort could not be inferred.",
+                       "i" = "Did you use insertTable() when adding the table to the cdm reference?"))
+
+    } else {
+      cli::cli_abort(c("x" = "Table name for cohort could not be inferred.",
+                       "i" = "The cohort table must be a permanent table when working with databases.",
+                       "i" = "Use dplyr::compute(temporary = FALSE, ...) to create a permanent table from a temporary table."))
+    }
+    }
 
   # columns
   notPresent <- cohortColumns("cohort")[!cohortColumns("cohort") %in% colnames(cohort)]

--- a/R/validate.R
+++ b/R/validate.R
@@ -81,6 +81,13 @@ validateCohortArgument <- function(cohort,
   assertLogical(checkInObservation, length = 1)
 
   assertClass(cohort, class = c("cohort_table", "cdm_table"), all = TRUE, call = call)
+
+  if(is.na(tableName(cohort))){
+    cli::cli_abort(c("x" = "Table name for cohort could not be inferred.",
+                     "i" = "The cohort table must be a permanent table when working with databases.",
+                     "i" = "Use dplyr::compute(temporary = FALSE, ...) to create a permanent table from a temporary table."))
+  }
+
   # columns
   notPresent <- cohortColumns("cohort")[!cohortColumns("cohort") %in% colnames(cohort)]
   if (length(notPresent) > 0) {

--- a/R/validate.R
+++ b/R/validate.R
@@ -83,15 +83,7 @@ validateCohortArgument <- function(cohort,
   assertClass(cohort, class = c("cohort_table", "cdm_table"), all = TRUE, call = call)
 
   if(is.na(tableName(cohort))){
-    if(cdmSourceType(cdm) == "local"){
-      cli::cli_abort(c("x" = "Table name for cohort could not be inferred.",
-                       "i" = "Did you use insertTable() when adding the table to the cdm reference?"))
-
-    } else {
-      cli::cli_abort(c("x" = "Table name for cohort could not be inferred.",
-                       "i" = "The cohort table must be a permanent table when working with databases.",
-                       "i" = "Use dplyr::compute(temporary = FALSE, ...) to create a permanent table from a temporary table."))
-    }
+    missingCohortTableNameError(cdm, validation = validation)
     }
 
   # columns

--- a/vignettes/cohorts.Rmd
+++ b/vignettes/cohorts.Rmd
@@ -177,7 +177,7 @@ asthma <- tibble(
   cohort_start_date = as.Date("2020-01-01"),
   cohort_end_date = as.Date("2020-01-10")
 )
-cdm$asthma <- asthma
+cdm <- insertTable(cdm, name = "asthma", table = asthma)
 cdm$asthma <- newCohortTable(cdm$asthma, 
                              cohortSetRef = tibble(cohort_definition_id = 1,
                                                    cohort_name = "asthma"))

--- a/vignettes/cohorts.Rmd
+++ b/vignettes/cohorts.Rmd
@@ -187,7 +187,7 @@ copd <- tibble(
   cohort_start_date = as.Date("2020-01-01"),
   cohort_end_date = as.Date("2020-01-10")
 )
-cdm$copd <- copd
+cdm <-  insertTable(cdm, name = "copd", table = copd)
 cdm$copd <- newCohortTable(cdm$copd, 
                            cohortSetRef = tibble(cohort_definition_id = 1,
                                                    cohort_name = "copd"))


### PR DESCRIPTION
closes #413

``` r
library(omopgenerics)
#> 
#> Attaching package: 'omopgenerics'
#> The following object is masked from 'package:stats':
#> 
#>     filter
library(IncidencePrevalence)
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union

cdm <- mockIncidencePrevalenceRef()
#> ■■■■■■■■■■■■■■■■ 50% | ETA: 2s
#> 
cdm <- generateDenominatorCohortSet(cdm, "denom")
#> ℹ Creating denominator cohorts
#> ✔ Cohorts created in 0 min and 5 sec
cdm$temp <- cdm$denom |> 
  compute() 
  
# still work
cohortCount(cdm$temp)
#> # A tibble: 1 × 3
#>   cohort_definition_id number_records number_subjects
#>                  <int>          <int>           <int>
#> 1                    1              1               1
attrition(cdm$temp)
#> # A tibble: 8 × 7
#>   cohort_definition_id number_records number_subjects reason_id reason          
#>                  <int>          <int>           <int>     <int> <chr>           
#> 1                    1              1               1         1 Starting popula…
#> 2                    1              1               1         2 Missing year of…
#> 3                    1              1               1         3 Missing sex     
#> 4                    1              1               1         4 Cannot satisfy …
#> 5                    1              1               1         5 No observation …
#> 6                    1              1               1         6 Doesn't satisfy…
#> 7                    1              1               1         7 Prior history r…
#> 8                    1              1               1        10 No observation …
#> # ℹ 2 more variables: excluded_records <int>, excluded_subjects <int>
settings(cdm$temp)
#> # A tibble: 1 × 9
#>   cohort_definition_id cohort_name        age_group sex   days_prior_observation
#>                  <int> <chr>              <chr>     <chr>                  <dbl>
#> 1                    1 denominator_cohor… 0 to 150  Both                       0
#> # ℹ 4 more variables: start_date <date>, end_date <date>,
#> #   target_cohort_definition_id <int>, target_cohort_name <chr>


# will fail with informative error
cdm$temp |> 
  recordCohortAttrition("a")
#> Error in `populateCohortSet()` at OMOPGenerics/R/classCohortTable.R:79:3:
#> ✖ Table name for cohort could not be inferred.
#> ℹ The cohort table must be a permanent table when working with databases.
#> ℹ Use dplyr::compute(temporary = FALSE, ...) to create a permanent table from a
#>   temporary table.
newCohortTable(cdm$temp)
#> Error in `populateCohortSet()` at OMOPGenerics/R/classCohortTable.R:79:3:
#> ✖ Table name for cohort could not be inferred.
#> ℹ The cohort table must be a permanent table when working with databases.
#> ℹ Use dplyr::compute(temporary = FALSE, ...) to create a permanent table from a
#>   temporary table.
validateCohortArgument(cdm$temp)
#> Error in `validateCohortArgument()`:
#> ✖ Table name for cohort could not be inferred.
#> ℹ The cohort table must be a permanent table when working with databases.
#> ℹ Use dplyr::compute(temporary = FALSE, ...) to create a permanent table from a
#>   temporary table.
```

<sup>Created on 2024-07-29 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
