### PR TITLE
speed up newOmopTable

### DIFF
--- a/R/classCdmReference.R
+++ b/R/classCdmReference.R
@@ -852,7 +852,8 @@ achillesColumns <- function(table, required = TRUE, version = "5.3") {
 }
 
 assertVersion <- function(version, call = parent.frame()) {
-  assertChoice(x = version, choices = c("5.3", "5.4"), call = call)
+  assertChoice(x = version, choices = c("5.3", "5.4"), call = call,
+               msg = "`version` must be a choice between 5.3 and 5.4; it can not contain NA; it can not be NULL.")
 }
 assertTableName <- function(table, version, type, call = parent.frame()) {
   assertChoice(x = table, choices = tableChoice(version, type), call = call)

--- a/R/classCdmReference.R
+++ b/R/classCdmReference.R
@@ -107,13 +107,15 @@ constructCdmReference <- function(tables, cdmName, cdmVersion, cdmSource) {
 }
 validateCdmReference <- function(cdm, soft) {
   # assert version
-  assertChoice(cdmVersion(cdm), c("5.3", "5.4"), length = 1)
+  version <- cdmVersion(cdm)
+  assertChoice(version, c("5.3", "5.4"), length = 1)
 
   # assert source
   assertClass(cdmSource(cdm), "cdm_source")
 
   # assert lowercase names
-  x <- names(cdm)[names(cdm) != tolower(names(cdm))]
+  xNames <- names(cdm)
+  x <- xNames[xNames != tolower(xNames)]
   if (length(x) > 0) {
     cli::cli_abort(
       "table names should be lower case; {combine(x)} {verb(x)} not."
@@ -122,20 +124,20 @@ validateCdmReference <- function(cdm, soft) {
 
   # assert compulsory tables
   compulsoryTables <- c("person", "observation_period")
-  x <- compulsoryTables[!compulsoryTables %in% names(cdm)]
+  x <- compulsoryTables[!compulsoryTables %in% xNames]
   if (length(x) > 0) {
     cli::cli_abort("{combine(x)} {verb(x)} not included in the cdm object")
   }
 
   # validate omop tables
-  omopTables <- omopTables(version = cdmVersion(cdm))
-  omopTables <- omopTables[omopTables %in% names(cdm)]
+  omopTables <- omopTables(version = version)
+  omopTables <- omopTables[omopTables %in% xNames]
   for (nm in omopTables) {
     if (nm %in% c("person", "observation_period")) {
-      cdm[[nm]] <- newOmopTable(cdm[[nm]], version = cdmVersion(cdm), cast = !soft)
+      cdm[[nm]] <- newOmopTable(cdm[[nm]], version = version, cast = !soft)
     } else {
       cdm[[nm]] <- tryCatch(
-        expr = {newOmopTable(cdm[[nm]], version = cdmVersion(cdm), cast = !soft)},
+        expr = {newOmopTable(cdm[[nm]], version = version, cast = !soft)},
         error = function(e){
           cli::cli_warn(c(
             "{nm} table not included in cdm because:", as.character(e)
@@ -147,11 +149,11 @@ validateCdmReference <- function(cdm, soft) {
   }
 
   # validate achilles tables
-  achillesTables <- achillesTables(version = cdmVersion(cdm))
-  achillesTables <- achillesTables[achillesTables %in% names(cdm)]
+  achillesTables <- achillesTables(version = version)
+  achillesTables <- achillesTables[achillesTables %in% xNames]
   for (nm in achillesTables) {
     cdm[[nm]] <- tryCatch(
-      expr = {newAchillesTable(cdm[[nm]], version = cdmVersion(cdm), cast = !soft)},
+      expr = {newAchillesTable(cdm[[nm]], version = version, cast = !soft)},
       error = function(e){
         cli::cli_warn(c(
           "{nm} table not included in cdm because:", as.character(e)

--- a/R/classCdmTable.R
+++ b/R/classCdmTable.R
@@ -25,8 +25,10 @@
 #' @export
 #'
 newCdmTable <- function(table, src, name) {
-  assertClass(src, class = "cdm_source")
-  assertCharacter(name, length = 1, na = TRUE)
+  assertClass(src, class = "cdm_source",
+              msg = "`src` does not have the class: cdm_source")
+  assertCharacter(name, length = 1, na = TRUE,
+                  msg = "`name` is not a character vector of length 1")
   table <- structure(.Data = table, tbl_source = src, tbl_name = name) |>
     addClass("cdm_table")
   if (any(colnames(table) != tolower(colnames(table)))) {
@@ -104,7 +106,8 @@ cdmReference <- function(table) {
 #' tableName(cdm$person)
 #' }
 tableName <- function(table) {
-  assertClass(table, "cdm_table")
+  assertClass(table, "cdm_table",
+              msg = "`table` does not have the class: cdm_table")
   attr(table, "tbl_name")
 }
 
@@ -140,7 +143,8 @@ tableName <- function(table) {
 #' tableSource(cdm$person)
 #' }
 tableSource <- function(table) {
-  assertClass(table, "cdm_table")
+  assertClass(table, "cdm_table",
+              msg = "`table` does not have the class: cdm_table")
   attr(table, "tbl_source")
 }
 

--- a/R/classOmopTable.R
+++ b/R/classOmopTable.R
@@ -26,16 +26,19 @@
 #'
 newOmopTable <- function(table, version = "5.3", cast = FALSE) {
   # create the structure
-  assertClass(table, class = "cdm_table")
-  table <- addClass(table, "omop_table")
-  name <- tableName(table)
+   assertClass(table, class = "cdm_table")
+   table <- addClass(table, "omop_table")
+   name <- attr(table, "tbl_name")
 
   # validation
-  if (!tableName(table) %in% omopTables()) {
+  if (!attr(table, "tbl_name") %in% tableChoice(version = version, type = "cdm_table")) {
     cli::cli_abort("{name} is not one of the omop cdm standard tables.")
   }
 
-  cols <- omopColumns(table = tableName(table), version = version)
+  cols <- getColumns(table = attr(table, "tbl_name"),
+                     version = version,
+                     type = "cdm_table",
+                     required = TRUE)
   checkColumnsCdm(table, name, cols)
   if (cast) table <- castOmopColumns(table, name, version)
 

--- a/R/classOmopTable.R
+++ b/R/classOmopTable.R
@@ -26,7 +26,8 @@
 #'
 newOmopTable <- function(table, version = "5.3", cast = FALSE) {
   # create the structure
-   assertClass(table, class = "cdm_table")
+   assertClass(table, class = "cdm_table",
+               msg = "table must be a cdm_table")
    table <- addClass(table, "omop_table")
    name <- attr(table, "tbl_name")
 


### PR DESCRIPTION
- skip function calls that validate again

@catalamarti this will speed up the creation of a cdm reference because it will skip calls to functions that have assertions, and instead goes to internal functions. Please take a look though as I worry this might have unintended side effects