### PR TITLE
check plausible observation period dates

### DIFF
--- a/R/cdmFromTables.R
+++ b/R/cdmFromTables.R
@@ -38,7 +38,7 @@
 #' observation_period <- tibble(
 #'   observation_period_id = 1, person_id = 1,
 #'   observation_period_start_date = as.Date("2000-01-01"),
-#'   observation_period_end_date = as.Date("2025-12-31"),
+#'   observation_period_end_date = as.Date("2023-12-31"),
 #'   period_type_concept_id = 0
 #' )
 #' cdm <- cdmFromTables(

--- a/R/classCdmReference.R
+++ b/R/classCdmReference.R
@@ -42,7 +42,7 @@
 #'   "observation_period" = tibble(
 #'     observation_period_id = 1, person_id = 1,
 #'     observation_period_start_date = as.Date("2000-01-01"),
-#'     observation_period_end_date = as.Date("2025-12-31"),
+#'     observation_period_end_date = as.Date("2023-12-31"),
 #'     period_type_concept_id = 0
 #'   ) |>
 #'     newCdmTable(newLocalSource(), "observation_period")
@@ -249,6 +249,8 @@ checkStartBeforeEndObservation <- function(x, call = parent.frame()) {
   }
 }
 checkPlausibleObservationDates <- function(x, call = parent.frame()) {
+
+  if(isTRUE(nrow(x |> utils::head(1) |> dplyr::collect()) > 0)){
   x <- x |>
     dplyr::summarise(minObsStart = min(.data$observation_period_start_date,
                                       na.rm = TRUE),
@@ -257,7 +259,7 @@ checkPlausibleObservationDates <- function(x, call = parent.frame()) {
     dplyr::collect()
 
   if(as.Date(x$minObsStart) < as.Date("1800-01-01")){
-    cli::cli_abort(
+    cli::cli_warn(
       message = c("There are observation period start dates before 1800-01-01",
                   "i" = "The earliest max observation period end date found is {x$minObsStart}"),
       call = call
@@ -265,11 +267,12 @@ checkPlausibleObservationDates <- function(x, call = parent.frame()) {
   }
 
   if(as.Date(x$maxObsEnd) > Sys.Date()){
-    cli::cli_abort(
+    cli::cli_warn(
       message = c("There are observation period end dates after the current date: {Sys.Date()}",
                   "i" = "The latest max observation period end date found is {x$maxObsEnd}"),
       call = call
     )
+  }
   }
 
 
@@ -297,7 +300,7 @@ checkPlausibleObservationDates <- function(x, call = parent.frame()) {
 #'     "observation_period" = tibble(
 #'       observation_period_id = 1:3, person_id = 1:3,
 #'       observation_period_start_date = as.Date("2000-01-01"),
-#'       observation_period_end_date = as.Date("2025-12-31"),
+#'       observation_period_end_date = as.Date("2023-12-31"),
 #'       period_type_concept_id = 0
 #'     )
 #'   ),
@@ -345,7 +348,7 @@ cdmName.cdm_table <- function(x) {
 #'     "observation_period" = tibble(
 #'       observation_period_id = 1:3, person_id = 1:3,
 #'       observation_period_start_date = as.Date("2000-01-01"),
-#'       observation_period_end_date = as.Date("2025-12-31"),
+#'       observation_period_end_date = as.Date("2023-12-31"),
 #'       period_type_concept_id = 0
 #'     )
 #'   ),
@@ -381,7 +384,7 @@ cdmVersion <- function(cdm) {
 #'     "observation_period" = tibble(
 #'       observation_period_id = 1:3, person_id = 1:3,
 #'       observation_period_start_date = as.Date("2000-01-01"),
-#'       observation_period_end_date = as.Date("2025-12-31"),
+#'       observation_period_end_date = as.Date("2023-12-31"),
 #'       period_type_concept_id = 0
 #'     )
 #'   ),
@@ -418,7 +421,7 @@ cdmSource <- function(cdm) {
 #'     "observation_period" = tibble(
 #'       observation_period_id = 1:3, person_id = 1:3,
 #'       observation_period_start_date = as.Date("2000-01-01"),
-#'       observation_period_end_date = as.Date("2025-12-31"),
+#'       observation_period_end_date = as.Date("2023-12-31"),
 #'       period_type_concept_id = 0
 #'     )
 #'   ),
@@ -454,7 +457,7 @@ cdmSourceType <- function(cdm) {
 #'     "observation_period" = tibble(
 #'       observation_period_id = 1:3, person_id = 1:3,
 #'       observation_period_start_date = as.Date("2000-01-01"),
-#'       observation_period_end_date = as.Date("2025-12-31"),
+#'       observation_period_end_date = as.Date("2023-12-31"),
 #'       period_type_concept_id = 0
 #'     )
 #'   ),
@@ -489,7 +492,7 @@ cdmSourceType <- function(cdm) {
 #'     "observation_period" = tibble(
 #'       observation_period_id = 1:3, person_id = 1:3,
 #'       observation_period_start_date = as.Date("2000-01-01"),
-#'       observation_period_end_date = as.Date("2025-12-31"),
+#'       observation_period_end_date = as.Date("2023-12-31"),
 #'       period_type_concept_id = 0
 #'     )
 #'   ),
@@ -541,7 +544,7 @@ cdmSourceType <- function(cdm) {
 #'     "observation_period" = dplyr::tibble(
 #'       observation_period_id = 1:3, person_id = 1:3,
 #'       observation_period_start_date = as.Date("2000-01-01"),
-#'       observation_period_end_date = as.Date("2025-12-31"),
+#'       observation_period_end_date = as.Date("2023-12-31"),
 #'       period_type_concept_id = 0
 #'     )
 #'   ),
@@ -658,7 +661,7 @@ cdmSourceType <- function(cdm) {
 #'     "observation_period" = dplyr::tibble(
 #'       observation_period_id = 1:3, person_id = 1:3,
 #'       observation_period_start_date = as.Date("2000-01-01"),
-#'       observation_period_end_date = as.Date("2025-12-31"),
+#'       observation_period_end_date = as.Date("2023-12-31"),
 #'       period_type_concept_id = 0
 #'     )
 #'   ),
@@ -725,7 +728,7 @@ print.cdm_reference <- function(x, ...) {
 #'     "observation_period" = dplyr::tibble(
 #'       observation_period_id = 1:3, person_id = 1:3,
 #'       observation_period_start_date = as.Date("2000-01-01"),
-#'       observation_period_end_date = as.Date("2025-12-31"),
+#'       observation_period_end_date = as.Date("2023-12-31"),
 #'       period_type_concept_id = 0
 #'     )
 #'   ),

--- a/R/classCdmTable.R
+++ b/R/classCdmTable.R
@@ -60,7 +60,7 @@ newCdmTable <- function(table, src, name) {
 #'     "observation_period" = tibble(
 #'       observation_period_id = 1:3, person_id = 1:3,
 #'       observation_period_start_date = as.Date("2000-01-01"),
-#'       observation_period_end_date = as.Date("2025-12-31"),
+#'       observation_period_end_date = as.Date("2023-12-31"),
 #'       period_type_concept_id = 0
 #'     )
 #'   ),
@@ -96,7 +96,7 @@ cdmReference <- function(table) {
 #'     "observation_period" = tibble(
 #'       observation_period_id = 1:3, person_id = 1:3,
 #'       observation_period_start_date = as.Date("2000-01-01"),
-#'       observation_period_end_date = as.Date("2025-12-31"),
+#'       observation_period_end_date = as.Date("2023-12-31"),
 #'       period_type_concept_id = 0
 #'     )
 #'   ),
@@ -133,7 +133,7 @@ tableName <- function(table) {
 #'     "observation_period" = tibble(
 #'       observation_period_id = 1:3, person_id = 1:3,
 #'       observation_period_start_date = as.Date("2000-01-01"),
-#'       observation_period_end_date = as.Date("2025-12-31"),
+#'       observation_period_end_date = as.Date("2023-12-31"),
 #'       period_type_concept_id = 0
 #'     )
 #'   ),

--- a/R/classCohortTable.R
+++ b/R/classCohortTable.R
@@ -43,7 +43,7 @@
 #' observation_period <- dplyr::tibble(
 #'   observation_period_id = 1, person_id = 1,
 #'   observation_period_start_date = as.Date("2000-01-01"),
-#'   observation_period_end_date = as.Date("2025-12-31"),
+#'   observation_period_end_date = as.Date("2023-12-31"),
 #'   period_type_concept_id = 0
 #' )
 #' cohort1 <- dplyr::tibble(
@@ -653,7 +653,7 @@ populateCohortCodelist <- function(table, cohortCodelistRef) {
 #' observation_period <- tibble(
 #'   observation_period_id = 1, person_id = 1,
 #'   observation_period_start_date = as.Date("2000-01-01"),
-#'   observation_period_end_date = as.Date("2025-12-31"),
+#'   observation_period_end_date = as.Date("2023-12-31"),
 #'   period_type_concept_id = 0
 #' )
 #' cdm <- cdmFromTables(

--- a/R/classOmopTable.R
+++ b/R/classOmopTable.R
@@ -65,7 +65,7 @@ newOmopTable <- function(table, version = "5.3", cast = FALSE) {
 #' observation_period <- dplyr::tibble(
 #'   observation_period_id = 1, person_id = 1,
 #'   observation_period_start_date = as.Date("2000-01-01"),
-#'   observation_period_end_date = as.Date("2025-12-31"),
+#'   observation_period_end_date = as.Date("2023-12-31"),
 #'   period_type_concept_id = 0
 #' )
 #' cdm <- cdmFromTables(

--- a/R/cohortCodelist.R
+++ b/R/cohortCodelist.R
@@ -39,7 +39,7 @@
 #' observation_period <- tibble(
 #'   observation_period_id = 1, person_id = 1,
 #'   observation_period_start_date = as.Date("2000-01-01"),
-#'   observation_period_end_date = as.Date("2025-12-31"),
+#'   observation_period_end_date = as.Date("2023-12-31"),
 #'   period_type_concept_id = 0
 #' )
 #' cohort <- tibble(

--- a/R/cohortCount.R
+++ b/R/cohortCount.R
@@ -34,7 +34,7 @@
 #' observation_period <- tibble(
 #'   observation_period_id = 1, person_id = 1,
 #'   observation_period_start_date = as.Date("2000-01-01"),
-#'   observation_period_end_date = as.Date("2025-12-31"),
+#'   observation_period_end_date = as.Date("2023-12-31"),
 #'   period_type_concept_id = 0
 #' )
 #' cohort <- tibble(

--- a/R/methodAttrition.R
+++ b/R/methodAttrition.R
@@ -46,7 +46,7 @@ attrition <- function(x) {
 #' observation_period <- tibble(
 #'   observation_period_id = 1, person_id = 1,
 #'   observation_period_start_date = as.Date("2000-01-01"),
-#'   observation_period_end_date = as.Date("2025-12-31"),
+#'   observation_period_end_date = as.Date("2023-12-31"),
 #'   period_type_concept_id = 0
 #' )
 #' cohort <- tibble(

--- a/R/methodBind.R
+++ b/R/methodBind.R
@@ -62,7 +62,7 @@ bind <- function(...) {
 #'     "observation_period" = tibble(
 #'       observation_period_id = 1:3, person_id = 1:3,
 #'       observation_period_start_date = as.Date("2000-01-01"),
-#'       observation_period_end_date = as.Date("2025-12-31"),
+#'       observation_period_end_date = as.Date("2023-12-31"),
 #'       period_type_concept_id = 0
 #'     )
 #'   ),
@@ -260,7 +260,7 @@ missingColumns <- function(cols, extra) {
 #'     "observation_period" = tibble(
 #'       observation_period_id = 1:3, person_id = 1:3,
 #'       observation_period_start_date = as.Date("2000-01-01"),
-#'       observation_period_end_date = as.Date("2025-12-31"),
+#'       observation_period_end_date = as.Date("2023-12-31"),
 #'       period_type_concept_id = 0
 #'     )
 #'   ),

--- a/R/methodDropTable.R
+++ b/R/methodDropTable.R
@@ -35,7 +35,7 @@
 #' observation_period <- tibble(
 #'   observation_period_id = 1, person_id = 1,
 #'   observation_period_start_date = as.Date("2000-01-01"),
-#'   observation_period_end_date = as.Date("2025-12-31"),
+#'   observation_period_end_date = as.Date("2023-12-31"),
 #'   period_type_concept_id = 0
 #' )
 #' cohort <- tibble(

--- a/R/methodInsertTable.R
+++ b/R/methodInsertTable.R
@@ -35,7 +35,7 @@
 #' observation_period <- tibble(
 #'   observation_period_id = 1, person_id = 1,
 #'   observation_period_start_date = as.Date("2000-01-01"),
-#'   observation_period_end_date = as.Date("2025-12-31"),
+#'   observation_period_end_date = as.Date("2023-12-31"),
 #'   period_type_concept_id = 0
 #' )
 #' cdm <- cdmFromTables(

--- a/R/methodSettings.R
+++ b/R/methodSettings.R
@@ -44,7 +44,7 @@ settings <- function(x) {
 #' observation_period <- tibble(
 #'   observation_period_id = 1, person_id = 1,
 #'   observation_period_start_date = as.Date("2000-01-01"),
-#'   observation_period_end_date = as.Date("2025-12-31"),
+#'   observation_period_end_date = as.Date("2023-12-31"),
 #'   period_type_concept_id = 0
 #' )
 #' cohort <- tibble(
@@ -97,7 +97,7 @@ settings.cohort_table <- function(x) {
 #' observation_period <- tibble(
 #'   observation_period_id = 1, person_id = 1,
 #'   observation_period_start_date = as.Date("2000-01-01"),
-#'   observation_period_end_date = as.Date("2025-12-31"),
+#'   observation_period_end_date = as.Date("2023-12-31"),
 #'   period_type_concept_id = 0
 #' )
 #' cohort <- tibble(

--- a/R/recordCohortAttrition.R
+++ b/R/recordCohortAttrition.R
@@ -36,7 +36,7 @@
 #' observation_period <- tibble(
 #'   observation_period_id = 1, person_id = 1,
 #'   observation_period_start_date = as.Date("2000-01-01"),
-#'   observation_period_end_date = as.Date("2025-12-31"),
+#'   observation_period_end_date = as.Date("2023-12-31"),
 #'   period_type_concept_id = 0
 #' )
 #' cohort <- tibble(

--- a/R/summary.R
+++ b/R/summary.R
@@ -34,7 +34,7 @@
 #' observation_period <- tibble(
 #'   observation_period_id = 1, person_id = 1,
 #'   observation_period_start_date = as.Date("2000-01-01"),
-#'   observation_period_end_date = as.Date("2025-12-31"),
+#'   observation_period_end_date = as.Date("2023-12-31"),
 #'   period_type_concept_id = 0
 #' )
 #' cdm <- cdmFromTables(
@@ -209,7 +209,7 @@ summary.cdm_reference <- function(object, ...) {
 #' observation_period <- tibble(
 #'   observation_period_id = 1, person_id = 1,
 #'   observation_period_start_date = as.Date("2000-01-01"),
-#'   observation_period_end_date = as.Date("2025-12-31"),
+#'   observation_period_end_date = as.Date("2023-12-31"),
 #'   period_type_concept_id = 0
 #' )
 #' cdm <- cdmFromTables(
@@ -347,7 +347,7 @@ addPkgDetails <- function(res) {
 #' observation_period <- tibble(
 #'   observation_period_id = 1, person_id = 1,
 #'   observation_period_start_date = as.Date("2000-01-01"),
-#'   observation_period_end_date = as.Date("2025-12-31"),
+#'   observation_period_end_date = as.Date("2023-12-31"),
 #'   period_type_concept_id = 0
 #' )
 #' cdm <- cdmFromTables(

--- a/R/validate.R
+++ b/R/validate.R
@@ -484,8 +484,13 @@ checkCategory <-
 #' validateCdmArgument
 #'
 #' @param cdm A cdm_reference object
-#' @param checkOverlapObservation TRUE to perform check on no overlap observation period
-#' @param checkStartBeforeEndObservation TRUE to perform check on correct observational start and end date
+#' @param checkOverlapObservation TRUE to perform check on no overlap
+#' observation period
+#' @param checkStartBeforeEndObservation TRUE to perform check on correct
+#' observational start and end date
+#' @param checkPlausibleObservationDates TRUE to perform check that there are
+#' no implausible observation period start dates (before 1800-01-01) or end
+#' dates (after the current date)
 #' @param validation How to perform validation: "error", "warning".
 #' @param call A call argument to pass to cli functions.
 #'
@@ -495,6 +500,7 @@ checkCategory <-
 validateCdmArgument <- function(cdm,
                                 checkOverlapObservation = FALSE,
                                 checkStartBeforeEndObservation = FALSE,
+                                checkPlausibleObservationDates = FALSE,
                                 validation = "error",
                                 call = parent.frame()) {
   assertValidation(validation, call = parent.frame())
@@ -522,6 +528,11 @@ validateCdmArgument <- function(cdm,
   if (isTRUE(checkStartBeforeEndObservation)){
     checkStartBeforeEndObservation(cdm$observation_period)
   }
+
+ if (isTRUE(checkPlausibleObservationDates)){
+   checkPlausibleObservationDates(cdm$observation_period)
+
+ }
 
   return(invisible(cdm))
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -133,7 +133,7 @@ person <- tibble(
 observation_period <- dplyr::tibble(
   observation_period_id = 1, person_id = 1,
   observation_period_start_date = as.Date("2000-01-01"),
-  observation_period_end_date = as.Date("2025-12-31"),
+  observation_period_end_date = as.Date("2023-12-31"),
   period_type_concept_id = 0
 )
 diabetes <- tibble(

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ person <- tibble(
 observation_period <- dplyr::tibble(
   observation_period_id = 1, person_id = 1,
   observation_period_start_date = as.Date("2000-01-01"),
-  observation_period_end_date = as.Date("2025-12-31"),
+  observation_period_end_date = as.Date("2023-12-31"),
   period_type_concept_id = 0
 )
 diabetes <- tibble(

--- a/man/attrition.cohort_table.Rd
+++ b/man/attrition.cohort_table.Rd
@@ -27,7 +27,7 @@ person <- tibble(
 observation_period <- tibble(
   observation_period_id = 1, person_id = 1,
   observation_period_start_date = as.Date("2000-01-01"),
-  observation_period_end_date = as.Date("2025-12-31"),
+  observation_period_end_date = as.Date("2023-12-31"),
   period_type_concept_id = 0
 )
 cohort <- tibble(

--- a/man/bind.cohort_table.Rd
+++ b/man/bind.cohort_table.Rd
@@ -44,7 +44,7 @@ cdm <- cdmFromTables(
     "observation_period" = tibble(
       observation_period_id = 1:3, person_id = 1:3,
       observation_period_start_date = as.Date("2000-01-01"),
-      observation_period_end_date = as.Date("2025-12-31"),
+      observation_period_end_date = as.Date("2023-12-31"),
       period_type_concept_id = 0
     )
   ),

--- a/man/bind.summarised_result.Rd
+++ b/man/bind.summarised_result.Rd
@@ -28,7 +28,7 @@ cdm <- cdmFromTables(
     "observation_period" = tibble(
       observation_period_id = 1:3, person_id = 1:3,
       observation_period_start_date = as.Date("2000-01-01"),
-      observation_period_end_date = as.Date("2025-12-31"),
+      observation_period_end_date = as.Date("2023-12-31"),
       period_type_concept_id = 0
     )
   ),

--- a/man/cash-.cdm_reference.Rd
+++ b/man/cash-.cdm_reference.Rd
@@ -31,7 +31,7 @@ cdm <- cdmFromTables(
     "observation_period" = tibble(
       observation_period_id = 1:3, person_id = 1:3,
       observation_period_start_date = as.Date("2000-01-01"),
-      observation_period_end_date = as.Date("2025-12-31"),
+      observation_period_end_date = as.Date("2023-12-31"),
       period_type_concept_id = 0
     )
   ),

--- a/man/cash-set-.cdm_reference.Rd
+++ b/man/cash-set-.cdm_reference.Rd
@@ -32,7 +32,7 @@ cdm <- cdmFromTables(
     "observation_period" = dplyr::tibble(
       observation_period_id = 1:3, person_id = 1:3,
       observation_period_start_date = as.Date("2000-01-01"),
-      observation_period_end_date = as.Date("2025-12-31"),
+      observation_period_end_date = as.Date("2023-12-31"),
       period_type_concept_id = 0
     )
   ),

--- a/man/cdmFromTables.Rd
+++ b/man/cdmFromTables.Rd
@@ -34,7 +34,7 @@ person <- tibble(
 observation_period <- tibble(
   observation_period_id = 1, person_id = 1,
   observation_period_start_date = as.Date("2000-01-01"),
-  observation_period_end_date = as.Date("2025-12-31"),
+  observation_period_end_date = as.Date("2023-12-31"),
   period_type_concept_id = 0
 )
 cdm <- cdmFromTables(

--- a/man/cdmName.Rd
+++ b/man/cdmName.Rd
@@ -29,7 +29,7 @@ cdm <- cdmFromTables(
     "observation_period" = tibble(
       observation_period_id = 1:3, person_id = 1:3,
       observation_period_start_date = as.Date("2000-01-01"),
-      observation_period_end_date = as.Date("2025-12-31"),
+      observation_period_end_date = as.Date("2023-12-31"),
       period_type_concept_id = 0
     )
   ),

--- a/man/cdmReference.Rd
+++ b/man/cdmReference.Rd
@@ -29,7 +29,7 @@ cdm <- cdmFromTables(
     "observation_period" = tibble(
       observation_period_id = 1:3, person_id = 1:3,
       observation_period_start_date = as.Date("2000-01-01"),
-      observation_period_end_date = as.Date("2025-12-31"),
+      observation_period_end_date = as.Date("2023-12-31"),
       period_type_concept_id = 0
     )
   ),

--- a/man/cdmSource.Rd
+++ b/man/cdmSource.Rd
@@ -29,7 +29,7 @@ cdm <- cdmFromTables(
     "observation_period" = tibble(
       observation_period_id = 1:3, person_id = 1:3,
       observation_period_start_date = as.Date("2000-01-01"),
-      observation_period_end_date = as.Date("2025-12-31"),
+      observation_period_end_date = as.Date("2023-12-31"),
       period_type_concept_id = 0
     )
   ),

--- a/man/cdmSourceType.Rd
+++ b/man/cdmSourceType.Rd
@@ -30,7 +30,7 @@ cdm <- cdmFromTables(
     "observation_period" = tibble(
       observation_period_id = 1:3, person_id = 1:3,
       observation_period_start_date = as.Date("2000-01-01"),
-      observation_period_end_date = as.Date("2025-12-31"),
+      observation_period_end_date = as.Date("2023-12-31"),
       period_type_concept_id = 0
     )
   ),

--- a/man/cdmVersion.Rd
+++ b/man/cdmVersion.Rd
@@ -29,7 +29,7 @@ cdm <- cdmFromTables(
     "observation_period" = tibble(
       observation_period_id = 1:3, person_id = 1:3,
       observation_period_start_date = as.Date("2000-01-01"),
-      observation_period_end_date = as.Date("2025-12-31"),
+      observation_period_end_date = as.Date("2023-12-31"),
       period_type_concept_id = 0
     )
   ),

--- a/man/cohortCodelist.Rd
+++ b/man/cohortCodelist.Rd
@@ -37,7 +37,7 @@ person <- tibble(
 observation_period <- tibble(
   observation_period_id = 1, person_id = 1,
   observation_period_start_date = as.Date("2000-01-01"),
-  observation_period_end_date = as.Date("2025-12-31"),
+  observation_period_end_date = as.Date("2023-12-31"),
   period_type_concept_id = 0
 )
 cohort <- tibble(

--- a/man/cohortCount.Rd
+++ b/man/cohortCount.Rd
@@ -27,7 +27,7 @@ person <- tibble(
 observation_period <- tibble(
   observation_period_id = 1, person_id = 1,
   observation_period_start_date = as.Date("2000-01-01"),
-  observation_period_end_date = as.Date("2025-12-31"),
+  observation_period_end_date = as.Date("2023-12-31"),
   period_type_concept_id = 0
 )
 cohort <- tibble(

--- a/man/collect.cdm_reference.Rd
+++ b/man/collect.cdm_reference.Rd
@@ -31,7 +31,7 @@ cdm <- cdmFromTables(
     "observation_period" = dplyr::tibble(
       observation_period_id = 1:3, person_id = 1:3,
       observation_period_start_date = as.Date("2000-01-01"),
-      observation_period_end_date = as.Date("2025-12-31"),
+      observation_period_end_date = as.Date("2023-12-31"),
       period_type_concept_id = 0
     )
   ),

--- a/man/dropTable.Rd
+++ b/man/dropTable.Rd
@@ -29,7 +29,7 @@ person <- tibble(
 observation_period <- tibble(
   observation_period_id = 1, person_id = 1,
   observation_period_start_date = as.Date("2000-01-01"),
-  observation_period_end_date = as.Date("2025-12-31"),
+  observation_period_end_date = as.Date("2023-12-31"),
   period_type_concept_id = 0
 )
 cohort <- tibble(

--- a/man/emptyCohortTable.Rd
+++ b/man/emptyCohortTable.Rd
@@ -30,7 +30,7 @@ person <- tibble(
 observation_period <- tibble(
   observation_period_id = 1, person_id = 1,
   observation_period_start_date = as.Date("2000-01-01"),
-  observation_period_end_date = as.Date("2025-12-31"),
+  observation_period_end_date = as.Date("2023-12-31"),
   period_type_concept_id = 0
 )
 cdm <- cdmFromTables(

--- a/man/emptyOmopTable.Rd
+++ b/man/emptyOmopTable.Rd
@@ -27,7 +27,7 @@ person <- dplyr::tibble(
 observation_period <- dplyr::tibble(
   observation_period_id = 1, person_id = 1,
   observation_period_start_date = as.Date("2000-01-01"),
-  observation_period_end_date = as.Date("2025-12-31"),
+  observation_period_end_date = as.Date("2023-12-31"),
   period_type_concept_id = 0
 )
 cdm <- cdmFromTables(

--- a/man/insertTable.Rd
+++ b/man/insertTable.Rd
@@ -29,7 +29,7 @@ race_concept_id = 0, ethnicity_concept_id = 0
 observation_period <- tibble(
 observation_period_id = 1, person_id = 1,
 observation_period_start_date = as.Date("2000-01-01"),
-observation_period_end_date = as.Date("2025-12-31"),
+observation_period_end_date = as.Date("2023-12-31"),
 period_type_concept_id = 0
 )
 cdm <- cdmFromTables(

--- a/man/newCdmReference.Rd
+++ b/man/newCdmReference.Rd
@@ -37,7 +37,7 @@ cdmTables <- list(
   "observation_period" = tibble(
     observation_period_id = 1, person_id = 1,
     observation_period_start_date = as.Date("2000-01-01"),
-    observation_period_end_date = as.Date("2025-12-31"),
+    observation_period_end_date = as.Date("2023-12-31"),
     period_type_concept_id = 0
   ) |>
     newCdmTable(newLocalSource(), "observation_period")

--- a/man/newCohortTable.Rd
+++ b/man/newCohortTable.Rd
@@ -46,7 +46,7 @@ person <- dplyr::tibble(
 observation_period <- dplyr::tibble(
   observation_period_id = 1, person_id = 1,
   observation_period_start_date = as.Date("2000-01-01"),
-  observation_period_end_date = as.Date("2025-12-31"),
+  observation_period_end_date = as.Date("2023-12-31"),
   period_type_concept_id = 0
 )
 cohort1 <- dplyr::tibble(

--- a/man/print.cdm_reference.Rd
+++ b/man/print.cdm_reference.Rd
@@ -30,7 +30,7 @@ cdm <- cdmFromTables(
     "observation_period" = dplyr::tibble(
       observation_period_id = 1:3, person_id = 1:3,
       observation_period_start_date = as.Date("2000-01-01"),
-      observation_period_end_date = as.Date("2025-12-31"),
+      observation_period_end_date = as.Date("2023-12-31"),
       period_type_concept_id = 0
     )
   ),

--- a/man/recordCohortAttrition.Rd
+++ b/man/recordCohortAttrition.Rd
@@ -31,7 +31,7 @@ person <- tibble(
 observation_period <- tibble(
   observation_period_id = 1, person_id = 1,
   observation_period_start_date = as.Date("2000-01-01"),
-  observation_period_end_date = as.Date("2025-12-31"),
+  observation_period_end_date = as.Date("2023-12-31"),
   period_type_concept_id = 0
 )
 cohort <- tibble(

--- a/man/settings.cohort_table.Rd
+++ b/man/settings.cohort_table.Rd
@@ -26,7 +26,7 @@ person <- tibble(
 observation_period <- tibble(
   observation_period_id = 1, person_id = 1,
   observation_period_start_date = as.Date("2000-01-01"),
-  observation_period_end_date = as.Date("2025-12-31"),
+  observation_period_end_date = as.Date("2023-12-31"),
   period_type_concept_id = 0
 )
 cohort <- tibble(

--- a/man/settings.summarised_result.Rd
+++ b/man/settings.summarised_result.Rd
@@ -26,7 +26,7 @@ person <- tibble(
 observation_period <- tibble(
   observation_period_id = 1, person_id = 1,
   observation_period_start_date = as.Date("2000-01-01"),
-  observation_period_end_date = as.Date("2025-12-31"),
+  observation_period_end_date = as.Date("2023-12-31"),
   period_type_concept_id = 0
 )
 cohort <- tibble(

--- a/man/sub-sub-.cdm_reference.Rd
+++ b/man/sub-sub-.cdm_reference.Rd
@@ -31,7 +31,7 @@ cdm <- cdmFromTables(
     "observation_period" = tibble(
       observation_period_id = 1:3, person_id = 1:3,
       observation_period_start_date = as.Date("2000-01-01"),
-      observation_period_end_date = as.Date("2025-12-31"),
+      observation_period_end_date = as.Date("2023-12-31"),
       period_type_concept_id = 0
     )
   ),

--- a/man/summary.cdm_reference.Rd
+++ b/man/summary.cdm_reference.Rd
@@ -28,7 +28,7 @@ person <- tibble(
 observation_period <- tibble(
   observation_period_id = 1, person_id = 1,
   observation_period_start_date = as.Date("2000-01-01"),
-  observation_period_end_date = as.Date("2025-12-31"),
+  observation_period_end_date = as.Date("2023-12-31"),
   period_type_concept_id = 0
 )
 cdm <- cdmFromTables(

--- a/man/summary.cohort_table.Rd
+++ b/man/summary.cohort_table.Rd
@@ -27,7 +27,7 @@ person <- tibble(
 observation_period <- tibble(
   observation_period_id = 1, person_id = 1,
   observation_period_start_date = as.Date("2000-01-01"),
-  observation_period_end_date = as.Date("2025-12-31"),
+  observation_period_end_date = as.Date("2023-12-31"),
   period_type_concept_id = 0
 )
 cdm <- cdmFromTables(

--- a/man/summary.summarised_result.Rd
+++ b/man/summary.summarised_result.Rd
@@ -28,7 +28,7 @@ person <- tibble(
 observation_period <- tibble(
   observation_period_id = 1, person_id = 1,
   observation_period_start_date = as.Date("2000-01-01"),
-  observation_period_end_date = as.Date("2025-12-31"),
+  observation_period_end_date = as.Date("2023-12-31"),
   period_type_concept_id = 0
 )
 cdm <- cdmFromTables(

--- a/man/tableName.Rd
+++ b/man/tableName.Rd
@@ -29,7 +29,7 @@ cdm <- cdmFromTables(
     "observation_period" = tibble(
       observation_period_id = 1:3, person_id = 1:3,
       observation_period_start_date = as.Date("2000-01-01"),
-      observation_period_end_date = as.Date("2025-12-31"),
+      observation_period_end_date = as.Date("2023-12-31"),
       period_type_concept_id = 0
     )
   ),

--- a/man/tableSource.Rd
+++ b/man/tableSource.Rd
@@ -29,7 +29,7 @@ cdm <- cdmFromTables(
     "observation_period" = tibble(
       observation_period_id = 1:3, person_id = 1:3,
       observation_period_start_date = as.Date("2000-01-01"),
-      observation_period_end_date = as.Date("2025-12-31"),
+      observation_period_end_date = as.Date("2023-12-31"),
       period_type_concept_id = 0
     )
   ),

--- a/man/validateCdmArgument.Rd
+++ b/man/validateCdmArgument.Rd
@@ -8,6 +8,7 @@ validateCdmArgument(
   cdm,
   checkOverlapObservation = FALSE,
   checkStartBeforeEndObservation = FALSE,
+  checkPlausibleObservationDates = FALSE,
   validation = "error",
   call = parent.frame()
 )
@@ -15,9 +16,15 @@ validateCdmArgument(
 \arguments{
 \item{cdm}{A cdm_reference object}
 
-\item{checkOverlapObservation}{TRUE to perform check on no overlap observation period}
+\item{checkOverlapObservation}{TRUE to perform check on no overlap
+observation period}
 
-\item{checkStartBeforeEndObservation}{TRUE to perform check on correct observational start and end date}
+\item{checkStartBeforeEndObservation}{TRUE to perform check on correct
+observational start and end date}
+
+\item{checkPlausibleObservationDates}{TRUE to perform check that there are
+no implausible observation period start dates (before 1800-01-01) or end
+dates (after the current date)}
 
 \item{validation}{How to perform validation: "error", "warning".}
 

--- a/tests/testthat/test-cdmFromTables.R
+++ b/tests/testthat/test-cdmFromTables.R
@@ -6,7 +6,7 @@ test_that("test cdmFromTables", {
   observation_period <- dplyr::tibble(
     observation_period_id = 1L, person_id = 1L,
     observation_period_start_date = as.Date("2000-01-01"),
-    observation_period_end_date = as.Date("2025-12-31"),
+    observation_period_end_date = as.Date("2023-12-31"),
     period_type_concept_id = 0L
   )
   cdm <- cdmFromTables(
@@ -65,7 +65,7 @@ test_that("test cdmFromTables", {
       "observation_period" = dplyr::tibble(
         observation_period_id = 1L, person_id = 1L,
         observation_period_start_date = as.Date("2000-01-01"),
-        observation_period_end_date = as.Date("2025-12-31"),
+        observation_period_end_date = as.Date("2023-12-31"),
         period_type_concept_id = 0L
       ),
       "cdm_source" = dplyr::tibble(
@@ -84,7 +84,7 @@ test_that("test cdmFromTables", {
   observation_period <- dplyr::tibble(
     observation_period_id = 1L, person_id = 1L,
     observation_period_start_date = as.Date(c("2000-01-01", "2020-01-01")),
-    observation_period_end_date = as.Date(c("2025-12-31", "2020-01-01")),
+    observation_period_end_date = as.Date(c("2023-12-31", "2020-01-01")),
     period_type_concept_id = 0L
   )
   expect_error(cdm <- cdmFromTables(
@@ -100,7 +100,7 @@ test_that("test cdmFromTables", {
   observation_period <- dplyr::tibble(
     observation_period_id = 1L, person_id = 1L,
     observation_period_start_date = as.Date(c("2050-01-01", "2020-01-01")),
-    observation_period_end_date = as.Date(c("2025-12-31", "2020-01-01")),
+    observation_period_end_date = as.Date(c("2023-12-31", "2020-01-01")),
     period_type_concept_id = 0L
   )
   expect_error(cdm <- cdmFromTables(
@@ -116,7 +116,7 @@ test_that("test cdmFromTables", {
   observation_period <- dplyr::tibble(
     observation_period_id = 1L, person_id = 1L,
     observation_period_start_date = as.Date(c("2000-01-01")),
-    observation_period_end_date = as.Date(c("2025-12-31")),
+    observation_period_end_date = as.Date(c("2023-12-31")),
     period_type_concept_id = 0L
   )
   drug_exposure <- dplyr::tibble(
@@ -142,7 +142,7 @@ test_that("test cdmFromTables", {
   observation_period <- dplyr::tibble(
     observation_period_id = 1L, person_id = 1L,
     observation_period_start_date = as.Date(c("2000-01-01")),
-    observation_period_end_date = as.Date(c("2025-12-31")),
+    observation_period_end_date = as.Date(c("2023-12-31")),
     period_type_concept_id = 0L
   )
   drug_exposure <- dplyr::tibble(

--- a/tests/testthat/test-classCdmReference.R
+++ b/tests/testthat/test-classCdmReference.R
@@ -9,7 +9,7 @@ test_that("test cdm_reference", {
     "observation_period" = dplyr::tibble(
       observation_period_id = 1L, person_id = 1L,
       observation_period_start_date = as.Date("2000-01-01"),
-      observation_period_end_date = as.Date("2025-12-31"),
+      observation_period_end_date = as.Date("2023-12-31"),
       period_type_concept_id = 0L
     ) |>
       newCdmTable(src, "observation_period")

--- a/tests/testthat/test-classCohortTable.R
+++ b/tests/testthat/test-classCohortTable.R
@@ -7,7 +7,7 @@ test_that("test create cohort", {
     observation_period_id = 1L,
     person_id = 1L,
     observation_period_start_date = as.Date("2000-01-01"),
-    observation_period_end_date = as.Date("2025-12-31"),
+    observation_period_end_date = as.Date("2023-12-31"),
     period_type_concept_id = 0L
   )
   cdm <- cdmFromTables(
@@ -265,7 +265,7 @@ test_that("test validateCohortArgument", {
     observation_period_id = 1L,
     person_id = 1L,
     observation_period_start_date = as.Date("2000-01-01"),
-    observation_period_end_date = as.Date("2025-12-31"),
+    observation_period_end_date = as.Date("2023-12-31"),
     period_type_concept_id = 0L
   )
   cdm <- cdmFromTables(
@@ -357,7 +357,7 @@ test_that("test error if attributes lost after class creation", {
     observation_period_id = 1L,
     person_id = 1L,
     observation_period_start_date = as.Date("2000-01-01"),
-    observation_period_end_date = as.Date("2025-12-31"),
+    observation_period_end_date = as.Date("2023-12-31"),
     period_type_concept_id = 0L
   )
   cdm <- cdmFromTables(

--- a/tests/testthat/test-cohortCodelist.R
+++ b/tests/testthat/test-cohortCodelist.R
@@ -6,7 +6,7 @@ test_that("test codelist from cohort", {
   observation_period <- dplyr::tibble(
     observation_period_id = 1L, person_id = 1L,
     observation_period_start_date = as.Date("2000-01-01"),
-    observation_period_end_date = as.Date("2025-12-31"),
+    observation_period_end_date = as.Date("2023-12-31"),
     period_type_concept_id = 0L
   )
   cohort1 <- dplyr::tibble(
@@ -74,7 +74,7 @@ test_that("test epected error cohort_codelist in wrong format", {
   observation_period <- dplyr::tibble(
     observation_period_id = 1L, person_id = 1L,
     observation_period_start_date = as.Date("2000-01-01"),
-    observation_period_end_date = as.Date("2025-12-31"),
+    observation_period_end_date = as.Date("2023-12-31"),
     period_type_concept_id = 0L
   )
   cohort <- dplyr::tibble(

--- a/tests/testthat/test-methodBind.R
+++ b/tests/testthat/test-methodBind.R
@@ -36,7 +36,7 @@ test_that("bind a cohort_table", {
       "observation_period" = dplyr::tibble(
         observation_period_id = c(1L, 2L, 3L), person_id = c(1L, 2L, 3L),
         observation_period_start_date = as.Date("2000-01-01"),
-        observation_period_end_date = as.Date("2025-12-31"),
+        observation_period_end_date = as.Date("2023-12-31"),
         period_type_concept_id = 0L
       )
     ),
@@ -119,7 +119,7 @@ test_that("bind a cohort_table", {
       "observation_period" = dplyr::tibble(
         observation_period_id = c(1L, 2L, 3L), person_id = c(1L, 2L, 3L),
         observation_period_start_date = as.Date("2000-01-01"),
-        observation_period_end_date = as.Date("2025-12-31"),
+        observation_period_end_date = as.Date("2023-12-31"),
         period_type_concept_id = 0L
       )
     ),

--- a/tests/testthat/test-methodDropSourceTable.R
+++ b/tests/testthat/test-methodDropSourceTable.R
@@ -6,7 +6,7 @@ test_that("dropSourceTable", {
   observation_period <- dplyr::tibble(
     observation_period_id = 1L, person_id = 1L,
     observation_period_start_date = as.Date("2000-01-01"),
-    observation_period_end_date = as.Date("2025-12-31"),
+    observation_period_end_date = as.Date("2023-12-31"),
     period_type_concept_id = 0L
   )
   cohort <- dplyr::tibble(

--- a/tests/testthat/test-methodInsertFromSource.R
+++ b/tests/testthat/test-methodInsertFromSource.R
@@ -6,7 +6,7 @@ test_that("insertFromSource", {
   observation_period <- dplyr::tibble(
     observation_period_id = 1L, person_id = 1L,
     observation_period_start_date = as.Date("2000-01-01"),
-    observation_period_end_date = as.Date("2025-12-31"),
+    observation_period_end_date = as.Date("2023-12-31"),
     period_type_concept_id = 0L
   )
   cdm <- cdmFromTables(

--- a/tests/testthat/test-methodReadSourceTable.R
+++ b/tests/testthat/test-methodReadSourceTable.R
@@ -6,7 +6,7 @@ test_that("readSourceTable", {
   observation_period <- dplyr::tibble(
     observation_period_id = 1L, person_id = 1L,
     observation_period_start_date = as.Date("2000-01-01"),
-    observation_period_end_date = as.Date("2025-12-31"),
+    observation_period_end_date = as.Date("2023-12-31"),
     period_type_concept_id = 0L
   )
   cohort <- dplyr::tibble(

--- a/tests/testthat/test-methodSummary.R
+++ b/tests/testthat/test-methodSummary.R
@@ -5,8 +5,8 @@ test_that("summary a cdm reference", {
   )
   observation_period <- dplyr::tibble(
     observation_period_id = c(1L, 2L), person_id = 1L,
-    observation_period_start_date = as.Date(c("2000-01-01", "2031-01-01")),
-    observation_period_end_date = as.Date(c("2025-12-31", "2032-01-01")),
+    observation_period_start_date = as.Date(c("2000-01-01", "2021-01-01")),
+    observation_period_end_date = as.Date(c("2019-12-31", "2022-01-01")),
     period_type_concept_id = 0L
   )
   cdm <- cdmFromTables(
@@ -61,7 +61,7 @@ test_that("summary a cdm reference", {
     ),
     value = c(
       as.character(Sys.Date()), "1", "2", rep(NA_character_, 7),
-      "2000-01-01", "2032-01-01"
+      "2000-01-01", "2022-01-01"
     )
   )
   for (k in seq_len(nrow(expt))) {
@@ -93,7 +93,7 @@ test_that("summary a generated cohort set", {
   observation_period <- dplyr::tibble(
     observation_period_id = 1L, person_id = 1L,
     observation_period_start_date = as.Date("2000-01-01"),
-    observation_period_end_date = as.Date("2025-12-31"),
+    observation_period_end_date = as.Date("2022-12-31"),
     period_type_concept_id = 0L
   )
   cohort <- dplyr::tibble(

--- a/tests/testthat/test-overwriteClasses.R
+++ b/tests/testthat/test-overwriteClasses.R
@@ -58,7 +58,7 @@ test_that("test that classes and attributes are keep", {
   observation_period <- dplyr::tibble(
     observation_period_id = 1L, person_id = 1L,
     observation_period_start_date = as.Date("2000-01-01"),
-    observation_period_end_date = as.Date("2025-12-31"),
+    observation_period_end_date = as.Date("2023-12-31"),
     period_type_concept_id = 0L
   )
   cohort1 <- dplyr::tibble(

--- a/tests/testthat/test-recordCohortAttrition.R
+++ b/tests/testthat/test-recordCohortAttrition.R
@@ -6,7 +6,7 @@ test_that("multiplication works", {
   observation_period <- dplyr::tibble(
     observation_period_id = 1L, person_id = 1L,
     observation_period_start_date = as.Date("2000-01-01"),
-    observation_period_end_date = as.Date("2025-12-31"),
+    observation_period_end_date = as.Date("2023-12-31"),
     period_type_concept_id = 0L
   )
   cohort <- dplyr::tibble(

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -7,7 +7,7 @@ test_that("test getCohortName and getCohortId", {
     observation_period_id = 1L,
     person_id = 1L,
     observation_period_start_date = as.Date("2000-01-01"),
-    observation_period_end_date = as.Date("2025-12-31"),
+    observation_period_end_date = Sys.Date(),
     period_type_concept_id = 0L
   )
   x <- dplyr::tibble(

--- a/tests/testthat/test-validate.R
+++ b/tests/testthat/test-validate.R
@@ -142,7 +142,7 @@ test_that("test validateCdmArgument", {
     "observation_period" = dplyr::tibble(
       observation_period_id = 1L, person_id = 1L,
       observation_period_start_date = as.Date("2000-01-01"),
-      observation_period_end_date = as.Date("2025-12-31"),
+      observation_period_end_date = as.Date("2023-12-31"),
       period_type_concept_id = 0L
     ))
 
@@ -160,7 +160,7 @@ test_that("test validateCdmArgument", {
     "observation_period" = dplyr::tibble(
       observation_period_id = c(1L,1L), person_id = c(1L,1L),
       observation_period_start_date = c(as.Date("2000-01-01"),as.Date("2000-01-01")),
-      observation_period_end_date = c(as.Date("2025-12-31"),as.Date("2023-01-01")),
+      observation_period_end_date = c(as.Date("2023-12-31"),as.Date("2023-01-01")),
       period_type_concept_id = c(0L,0L)
     ))
   class(cdm_object) <- c("cdm_reference")
@@ -190,7 +190,7 @@ test_that("test validateCdmArgument", {
       period_type_concept_id = c(0L,0L)
     ))
   class(cdm_object) <- c("cdm_reference")
-  expect_error(
+  expect_warning(
     validateCdmArgument(
       cdm_object,
       checkPlausibleObservationDates = TRUE
@@ -203,7 +203,7 @@ test_that("test validateCdmArgument", {
     )
   )
 
-  # implausible ending observation date
+  # implausible ending observation date - currently a warning instead of e
   cdm_object <- list(
     "observation_period" = dplyr::tibble(
       observation_period_id = c(1L,1L), person_id = c(1L,1L),
@@ -212,7 +212,7 @@ test_that("test validateCdmArgument", {
       period_type_concept_id = c(0L,0L)
     ))
   class(cdm_object) <- c("cdm_reference")
-  expect_error(
+  expect_warning(
     validateCdmArgument(
       cdm_object,
       checkPlausibleObservationDates = TRUE
@@ -224,6 +224,18 @@ test_that("test validateCdmArgument", {
       checkPlausibleObservationDates = FALSE
     )
   )
+
+
+  # no errors or warnings if cdm is empty
+  expect_no_error(
+    validateCdmArgument(
+      emptyCdmReference("test"),
+      checkOverlapObservation = TRUE,
+      checkStartBeforeEndObservation = TRUE,
+      checkPlausibleObservationDates = TRUE
+    )
+    )
+
 
 })
 

--- a/tests/testthat/test-validate.R
+++ b/tests/testthat/test-validate.R
@@ -117,7 +117,7 @@ test_that("test validateAgeGroup", {
 
 })
 
-test_that("test validateResultArguemnt", {
+test_that("test validateCdmArgument", {
 
 
 
@@ -181,6 +181,49 @@ test_that("test validateResultArguemnt", {
     )
   )
 
+  # implausible starting observation date
+  cdm_object <- list(
+    "observation_period" = dplyr::tibble(
+      observation_period_id = c(1L,1L), person_id = c(1L,1L),
+      observation_period_start_date = c(as.Date("1700-01-01"),as.Date("2000-01-01")),
+      observation_period_end_date = c(as.Date("2000-01-01"),as.Date("2023-01-01")),
+      period_type_concept_id = c(0L,0L)
+    ))
+  class(cdm_object) <- c("cdm_reference")
+  expect_error(
+    validateCdmArgument(
+      cdm_object,
+      checkPlausibleObservationDates = TRUE
+    )
+  )
+  expect_no_error(
+    validateCdmArgument(
+      cdm_object,
+      checkPlausibleObservationDates = FALSE
+    )
+  )
+
+  # implausible ending observation date
+  cdm_object <- list(
+    "observation_period" = dplyr::tibble(
+      observation_period_id = c(1L,1L), person_id = c(1L,1L),
+      observation_period_start_date = c(as.Date("2000-01-01"),as.Date("2000-01-02")),
+      observation_period_end_date = c(as.Date("2000-01-01"),as.Date("2100-01-01")),
+      period_type_concept_id = c(0L,0L)
+    ))
+  class(cdm_object) <- c("cdm_reference")
+  expect_error(
+    validateCdmArgument(
+      cdm_object,
+      checkPlausibleObservationDates = TRUE
+    )
+  )
+  expect_no_error(
+    validateCdmArgument(
+      cdm_object,
+      checkPlausibleObservationDates = FALSE
+    )
+  )
 
 })
 

--- a/vignettes/cohorts.Rmd
+++ b/vignettes/cohorts.Rmd
@@ -43,7 +43,7 @@ person <- tibble(
 observation_period <- dplyr::tibble(
   observation_period_id = c(1,2), person_id = c(1,2),
   observation_period_start_date = as.Date("2000-01-01"),
-  observation_period_end_date = as.Date("2025-12-31"),
+  observation_period_end_date = as.Date("2021-12-31"),
   period_type_concept_id = 0
 )
 cdm <- cdmFromTables(


### PR DESCRIPTION
closes #436 

@catalamarti note, I think it is quite likely this breaks test cases/ examples of downstream packages that might use implausible dates. It will also likely be a not too infrequent problem for data partners (although ensuring this means when our packages set study periods based on the data we will be at a much reduced risk of estimating incidence rates in 2099 etc)